### PR TITLE
Fix examples of commutativity

### DIFF
--- a/20-00-Commutative.tex
+++ b/20-00-Commutative.tex
@@ -41,8 +41,8 @@ Viewing $\circ$ as a function from $S\times S$ to $S$, the commutativity of $\ci
 
 Some common examples of commutative operations are 
 \begin{itemize}
-\item addition over the integers: $m+n=m+n$ for all integers $m,n$
-\item multiplication over the integers: $m\cdot n=m\cdot n$ for all integers $m,n$
+\item addition over the integers: $m+n=n+m$ for all integers $m,n$
+\item multiplication over the integers: $m\cdot n=n\cdot m$ for all integers $m,n$
 \item addition over $n \times n$ matrices, $A+B=B+A$ for all $n\times n$ matrices $A,B$, and
 \item multiplication over the reals: $rs=sr$, for all real numbers $r,s$.
 \end{itemize}


### PR DESCRIPTION
This fixes the examples, they were in the wrong order. 